### PR TITLE
Various fixes to be able to put superpowers inside the flatpak sandbox

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const yargs = require("yargs");
 const fs = require("fs");
 const execSync = require("child_process").execSync;
 const path = require("path");
@@ -8,6 +9,17 @@ const rootPackage = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`, {
 const publicPackage = JSON.parse(fs.readFileSync(`${__dirname}/../public/package.json`, { encoding: "utf8" }));
 publicPackage.version = rootPackage.version;
 publicPackage.dependencies = rootPackage.dependencies;
+
+const argv = yargs.argv;
+let platform = argv._[0];
+let arch = argv._[1];
+
+if (arch == null) {
+  arch = "all";
+}
+if (platform == null) {
+  platform = "all";
+}
 
 fs.writeFileSync(`${__dirname}/../public/package.json`, JSON.stringify(publicPackage, null, 2) + "\n");
 
@@ -19,7 +31,7 @@ execSync("npm install --production", { cwd: `${__dirname}/../public`, stdio: "in
 // See https://github.com/electron-userland/electron-packager/issues/413
 execSync("npm install rcedit@0.5.0 electron-packager@7.1.0", { stdio: "inherit" });
 
-console.log("Running electron-packager...");
+console.log(`Running electron-packager for platform '${platform}' and arch '${arch}'...`);
 
 const packager = require("electron-packager");
 const year = new Date().getFullYear();
@@ -27,7 +39,8 @@ const year = new Date().getFullYear();
 packager({
   dir: "public",
   name: "Superpowers",
-  all: true,
+  platform: platform,
+  arch: arch,
   version: publicPackage.superpowers.electron,
   out: "packages",
   icon: "icons/superpowers",

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,8 @@ import getLanguageCode from "./getLanguageCode";
 import * as SupAppIPC from "./ipc";
 
 let corePath: string;
-let userDataPath: string;
+let roUserDataPath: string;
+let rwUserDataPath: string;
 
 let mainWindow: Electron.BrowserWindow;
 let trayIcon: Electron.Tray;
@@ -48,7 +49,7 @@ function startCleanExit() {
 electron.ipcMain.on("ready-to-quit", (event) => {
   if (event.sender !== mainWindow.webContents) return;
 
-  SupAppIPC.saveAuthorizations(userDataPath);
+  SupAppIPC.saveAuthorizations(rwUserDataPath);
 
   console.log("Exited cleanly.");
   isReadyToQuit = true;
@@ -60,13 +61,14 @@ electron.ipcMain.on("show-main-window", () => { restoreMainWindow(); });
 function onAppReady() {
   menu.setup(electron.app);
 
-  getPaths((dataPathErr, pathToCore, pathToUserData) => {
-    userDataPath = pathToUserData;
+  getPaths((dataPathErr, pathToCore, pathToRoUserData, pathToRwUserData) => {
+    roUserDataPath = pathToRoUserData;
+    rwUserDataPath = pathToRwUserData;
     corePath = pathToCore;
 
-    SupAppIPC.loadAuthorizations(userDataPath);
+    SupAppIPC.loadAuthorizations(rwUserDataPath);
 
-    getLanguageCode(userDataPath, (languageCode) => {
+    getLanguageCode(rwUserDataPath, (languageCode) => {
       i18n.setLanguageCode(languageCode);
       i18n.load([ "startup", "tray" ], () => {
         if (dataPathErr != null) {
@@ -135,7 +137,7 @@ function setupMainWindow() {
   mainWindow.loadURL(`file://${__dirname}/renderer/${i18n.getLocalizedFilename("index.html")}`);
 
   mainWindow.webContents.on("did-finish-load", () => {
-    mainWindow.webContents.send("init", corePath, userDataPath, i18n.languageCode);
+    mainWindow.webContents.send("init", corePath, roUserDataPath, rwUserDataPath, i18n.languageCode);
     mainWindow.show();
   });
 

--- a/src/renderer/flatpak.ts
+++ b/src/renderer/flatpak.ts
@@ -1,0 +1,11 @@
+import * as path from "path";
+import * as fs from "fs";
+
+export function underFlatpak() {
+  if (process.env.XDG_RUNTIME_DIR == null) {
+    return false;
+  }
+
+  const flatpakInfo = path.join(process.env.XDG_RUNTIME_DIR, "flatpak-info");
+  return fs.existsSync(flatpakInfo) && fs.statSync(flatpakInfo).isFile();
+}

--- a/src/renderer/forkServerProcess.ts
+++ b/src/renderer/forkServerProcess.ts
@@ -13,7 +13,7 @@ export default function forkSererProcess(extraArgs: string[] = []) {
   // for (const key in nodeProcess.env) serverEnv[key] = nodeProcess.env[key];
 
   // So instead, we'll just copy the environment variables we definitely need
-  for (const varName of [ "NODE_ENV", "APPDATA", "HOME", "XDG_DATA_HOME" ]) {
+  for (const varName of [ "NODE_ENV", "APPDATA", "HOME", "XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "LD_LIBRARY_PATH", "GST_PLUGIN_SYSTEM_PATH", "XDG_CONFIG_DIRS", "PATH", "GI_TYPELIB_PATH" ]) {
     if (process.env[varName] != null) serverEnv[varName] = process.env[varName];
   }
 

--- a/src/renderer/forkServerProcess.ts
+++ b/src/renderer/forkServerProcess.ts
@@ -19,7 +19,7 @@ export default function forkSererProcess(extraArgs: string[] = []) {
 
   const serverProcess = fork(
     serverPath,
-    [ `--data-path=${settings.userDataPath}` ].concat(extraArgs),
+    [ `--data-path=${settings.roUserDataPath}`, `--rw-data-path=${settings.rwUserDataPath}` ].concat(extraArgs),
     { silent: true, env: serverEnv }
   );
   return serverProcess;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -16,6 +16,7 @@ import openServerSettings from "./tabs/openServerSettings";
 import * as localServer from "./localServer";
 import * as chat from "./chat";
 import WelcomeDialog from "./WelcomeDialog";
+import * as flatpak from "./flatpak";
 
 electron.ipcRenderer.on("init", onInitialize);
 electron.ipcRenderer.on("quit", onQuit);
@@ -71,7 +72,10 @@ function start() {
 
   splashScreen.fadeOut(() => {
     if (settings.nickname == null) {
-      async.series([ showWelcomeDialog, installFirstSystem ]);
+      let actions = [ showWelcomeDialog, installFirstSystem ];
+      if (flatpak.underFlatpak())
+        actions = [ showWelcomeDialog, startLocalServer ];
+      async.series(actions);
     } else {
       me.start();
       chat.start();
@@ -105,6 +109,11 @@ function showWelcomeDialog(callback: Function) {
   });
 }
 
+function startLocalServer(callback: Function) {
+  localServer.start();
+  callback();
+}
+
 function installFirstSystem(callback: Function) {
   const label = i18n.t("welcome:askGameInstall.prompt");
   const options = {
@@ -115,8 +124,7 @@ function installFirstSystem(callback: Function) {
 
   new dialogs.ConfirmDialog(label, options, (installGame) => {
     if (!installGame) {
-      localServer.start();
-      callback();
+      startLocalServer(callback);
       return;
     }
 
@@ -160,6 +168,8 @@ function installFirstSystem(callback: Function) {
 }
 
 function updateSystemsAndPlugins() {
+  if (flatpak.underFlatpak()) { localServer.start(); return; }
+
   serverSettingsSystems.getRegistry((registry) => {
     if (registry == null) { localServer.start(); return; }
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -26,8 +26,8 @@ const namespaces = [
   "welcome", "home"
 ];
 
-function onInitialize(sender: any, corePath: string, userDataPath: string, languageCode: string) {
-  settings.setPaths(corePath, userDataPath);
+function onInitialize(sender: any, corePath: string, roUserDataPath: string, rwUserDataPath: string, languageCode: string) {
+  settings.setPaths(corePath, roUserDataPath, rwUserDataPath);
   i18n.setLanguageCode(languageCode);
   i18n.load(namespaces, () => { settings.load(onSettingsLoaded); });
 }
@@ -42,7 +42,7 @@ function onQuit() {
 function onSettingsLoaded(err: Error) {
   if (err != null) {
     const label = i18n.t("startup:errors.couldNotLoadSettings", {
-      settingsPath: `${settings.userDataPath}/settings.json`,
+      settingsPath: `${settings.rwUserDataPath}/settings.json`,
       reason: err.message
     });
     const options = {

--- a/src/renderer/serverSettings/index.ts
+++ b/src/renderer/serverSettings/index.ts
@@ -79,7 +79,7 @@ function getServerConfig() {
 
   let localConfig: ServerConfig;
   try {
-    localConfig = JSON.parse(fs.readFileSync(`${settings.userDataPath}/config.json`, { encoding: "utf8" }));
+    localConfig = JSON.parse(fs.readFileSync(`${settings.rwUserDataPath}/config.json`, { encoding: "utf8" }));
   } catch (err) { /* Ignore */ }
   if (localConfig == null) localConfig = {} as any;
 
@@ -93,7 +93,7 @@ function getServerConfig() {
 }
 
 function onOpenProjectsFolderClick() {
-  electron.shell.openExternal(`${settings.userDataPath}/projects/`);
+  electron.shell.openExternal(`${settings.rwUserDataPath}/projects/`);
 }
 
 function onChangeAutoStartServer() {
@@ -149,7 +149,7 @@ export function applyScheduledSave() {
     maxRecentBuilds: parseInt(maxRecentBuildsElt.value, 10)
   };
 
-  fs.writeFileSync(`${settings.userDataPath}/config.json`, JSON.stringify(config, null, 2) + "\n", { encoding: "utf8" });
+  fs.writeFileSync(`${settings.rwUserDataPath}/config.json`, JSON.stringify(config, null, 2) + "\n", { encoding: "utf8" });
 
   clearTimeout(scheduleSaveTimeoutId);
   scheduleSaveTimeoutId = null;

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -2,7 +2,8 @@ import * as fs from "fs";
 import * as i18n from "../shared/i18n";
 
 export let corePath: string;
-export let userDataPath: string;
+export let roUserDataPath: string;
+export let rwUserDataPath: string;
 
 export let favoriteServers: ServerEntry[];
 export let favoriteServersById: { [id: string]: ServerEntry };
@@ -14,9 +15,10 @@ export let nickname: string;
 export let presence: "online"|"away"|"offline";
 export let savedChatrooms: string[];
 
-export function setPaths(newCorePath: string, newUserDataPath: string) {
+export function setPaths(newCorePath: string, newRoUserDataPath: string, newRwUserDataPath: string) {
   corePath = newCorePath;
-  userDataPath = newUserDataPath;
+  roUserDataPath = newRoUserDataPath;
+  rwUserDataPath = newRwUserDataPath;
 }
 
 export function setNickname(newNickname: string) {
@@ -36,7 +38,7 @@ export function setAutoStartServer(enabled: boolean) {
 }
 
 export function load(callback: (err: Error) => void) {
-  const settingsPath = `${userDataPath}/settings.json`;
+  const settingsPath = `${rwUserDataPath}/settings.json`;
   console.log(`Loading settings from ${settingsPath}.`);
 
   fs.readFile(settingsPath, { encoding: "utf8" }, (err, dataJSON) => {
@@ -97,7 +99,7 @@ export function applyScheduledSave() {
     savedChatrooms
   };
 
-  fs.writeFileSync(`${userDataPath}/settings.json`, JSON.stringify(data, null, 2) + "\n", { encoding: "utf8" });
+  fs.writeFileSync(`${rwUserDataPath}/settings.json`, JSON.stringify(data, null, 2) + "\n", { encoding: "utf8" });
 
   clearTimeout(scheduleSaveTimeoutId);
   scheduleSaveTimeoutId = null;

--- a/src/renderer/updateManager.ts
+++ b/src/renderer/updateManager.ts
@@ -12,6 +12,7 @@ import * as systemServerSettings from "./serverSettings/systems";
 import * as i18n from "../shared/i18n";
 import * as splashScreen from "./splashScreen";
 import fetch from "../shared/fetch";
+import * as flatpak from "./flatpak";
 
 /* tslint:disable */
 const https: typeof dummy_https = require("follow-redirects").https;
@@ -24,7 +25,14 @@ if (appVersion === "0.0.0-dev") {
 } else appVersion = `v${appVersion}`;
 
 export function checkForUpdates(callback: (err: Error) => void) {
-  async.series([ checkAppUpdate, checkCoreUpdate ], callback);
+  let updateRoutines = [ checkAppUpdate, checkCoreUpdate ];
+  if (flatpak.underFlatpak())
+    updateRoutines = [ checkNoUpdates ];
+  async.series(updateRoutines, callback);
+}
+
+function checkNoUpdates(callback: (err: Error) => void) {
+  callback(null);
 }
 
 function checkAppUpdate(callback: (err: Error) => void) {


### PR DESCRIPTION
This depends currently on the PR in core - https://github.com/superpowers/superpowers-core/pull/158

We also disable updates when we are inside the flatpak, as the flatpakked app already has the app, core and the game system with the plugins inside the read only directory (`/app`).

Also, we need to pass more env vars to the server, because inside the flatpak sandbox, libraries coming from the project or its dependencies are put inside `/app`, but the libraries from the runtime are inside `/lib` (for example the gtk2 library). The linker knows about both of those locations thanks to the `LD_LIBRARY_PATH` env var. I'm also forwarding all the variables that point to the directories set up by flatpak.